### PR TITLE
fix: ensure min is less than or equal to max

### DIFF
--- a/lib/__tests__/index.spec.ts
+++ b/lib/__tests__/index.spec.ts
@@ -77,7 +77,7 @@ describe('#bankName', () => {
   ])('%s (%s-%s)', (bank, min, max) => {
     return new Array(1 + max - min)
       .fill(0)
-      .map((v) => min + v)
+      .map((_, i) => min + i)
       .forEach((value) => {
         expect(bankName(value)).toEqual(bank)
       })

--- a/lib/clearingNumbers.ts
+++ b/lib/clearingNumbers.ts
@@ -144,8 +144,8 @@ export default [
     bank: 'FTCS',
     ranges: [
       {
-        max: 9770,
-        min: 9779,
+        max: 9779,
+        min: 9770,
       },
     ],
   },
@@ -198,8 +198,8 @@ export default [
     bank: 'Klarna Bank',
     ranges: [
       {
-        max: 9780,
-        min: 9789,
+        max: 9789,
+        min: 9780,
       },
     ],
   },


### PR DESCRIPTION
Fix some inverted ranges and fix the test to actually check the entire range returns the correct bank.